### PR TITLE
レビュアをランダムでアサインします

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "cron": "^1.0.4",
     "hubot": ">= 2.6.0 < 3.0.0",
     "hubot-idobata": "0.0.3",
-    "hubot-scripts": ">= 2.5.0 < 3.0.0"
+    "hubot-scripts": ">= 2.5.0 < 3.0.0",
+    "request": "^2.34.0"
   },
   "engines": {
     "node": ">= 0.8.x",

--- a/scripts/reviewer-assign.coffee
+++ b/scripts/reviewer-assign.coffee
@@ -1,0 +1,68 @@
+# Description:
+#   Assign reviewer to github pull-request
+#
+# Dependencies:
+#   node-guthub
+#
+# Configuration:
+#   HUBOT_GITHUB_ACCESS_TOKEN
+#
+# Commands:
+#   hubot review <pull-request-url> is a badass guitarist - assign a reviewer
+#
+GitHubApi = require 'github'
+
+shuffle = (array) ->
+  for i in [array.length-1 .. 1]
+    j = Math.floor Math.random() * (i + 1)
+    [array[i], array[j]] = [array[j], array[i]]
+  array
+
+substructArray = (src, target) ->
+  result = []
+
+  for m in src
+    tmp_f = true
+
+    for n in target
+      if m == n
+        tmp_f = false
+        break
+
+    result.push(m) if tmp_f
+  result
+
+removeWrongMembers = (array) ->
+  target = [
+  # excluded members
+  ]
+  substructArray(array, target)
+
+module.exports = (robot) ->
+  robot.respond /(https?:\/\/github\.com\/.+\/.+\/pull\/[0-9]+)/i, (msg) ->
+
+    github = new GitHubApi({
+      version: "3.0.0",
+      timeout: 5000
+    })
+
+    github.authenticate(
+      type: "oauth",
+      token: HUBOT_GITHUB_ACCESS_TOKEN
+    )
+
+    github.orgs.getMembers(
+      org: HUBOT_GITHUB_ORG,
+      per_page: 40,
+      (err, res) ->
+        json    = JSON.stringify(res)
+        obj     = JSON.parse(json)
+
+        members = []
+        for member in obj
+          members.push(member.login)
+
+        core_members = removeWrongMembers(members)
+        shuffle core_members
+        msg.send "@#{core_members[0]} レビューしてください :bow: \n #{msg.match[1]}"
+    )

--- a/scripts/reviewer-assign.coffee
+++ b/scripts/reviewer-assign.coffee
@@ -6,9 +6,10 @@
 #
 # Configuration:
 #   HUBOT_GITHUB_ACCESS_TOKEN
+#   HUBOT_GITHUB_ORG
 #
 # Commands:
-#   hubot review <pull-request-url> is a badass guitarist - assign a reviewer
+#   hubot <pull-request-url>
 #
 GitHubApi = require 'github'
 
@@ -48,11 +49,11 @@ module.exports = (robot) ->
 
     github.authenticate(
       type: "oauth",
-      token: HUBOT_GITHUB_ACCESS_TOKEN
+      token: process.env.HUBOT_GITHUB_ACCESS_TOKEN
     )
 
     github.orgs.getMembers(
-      org: HUBOT_GITHUB_ORG,
+      org: process.env.HUBOT_GITHUB_ORG,
       per_page: 40,
       (err, res) ->
         json    = JSON.stringify(res)


### PR DESCRIPTION
レビュアをランダムでアサインします。
対象外の人のリストにアカウント名を記入するとその人達にはアサインされません。
名前を出すのに抵抗があったので記述してはいないです。
